### PR TITLE
Bump ubuntu from 18.04 to 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL maintainer="info@thorstenreichelt.de"
 


### PR DESCRIPTION
Bumps ubuntu from 18.04 to 20.04.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>