### PR TITLE
add release 2.1.0 to master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,12 @@ ARG DEBIAN_FRONTEND="noninteractive"
 ARG OMADA_REPO=https://static.tp-link.com/2020/202012/20201225
 ARG OMADA_VERSION=3.2.14
 
-ENV JAVA_HOME=/opt/tplink/EAPController/jre/bin/java \
-    PATH=${PATH}:/opt/tplink/EAPController/jre/bin/java 
+ENV JAVA_HOME=/opt/tplink/EAPController/jre/bin/java
+ENV PATH=${PATH}:/opt/tplink/EAPController/jre/bin/java 
+ENV HTTPPORT=8088
+ENV HTTPSPORT=8043
 
-RUN apt-get update -qq && apt-get install -y --no-install-recommends\
+RUN apt-get update -qq && apt-get install -y --no-install-recommends \
 	tar=1.30+dfsg-7ubuntu0.20.04.1 \
 	wget=1.20.3-1ubuntu1 \
 	net-tools=1.60+git20180626.aebd88e-1ubuntu1 \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ TP-Links Omada Controller for EAPs running as a Docker Container for simplified 
     docker run \
       --name omada-controller \
       --hostname omada \
-      --restart always \      
+      --restart always \
+      --env HTTPPORT=8088 \
+      --env HTTPSPORT=8043 \
       --volume 'omada-data:/opt/tplink/EAPController/data' \
       --volume 'omada-work:/opt/tplink/EAPController/work' \
       --volume 'omada-logs:/opt/tplink/EAPController/logs' \
@@ -21,16 +23,22 @@ TP-Links Omada Controller for EAPs running as a Docker Container for simplified 
     services:
         omada-controller:
             container_name: omada-controller
-            hostname: omada        
+            hostname: omada
             restart: always
+            environment:
+                - HTTPPORT=8088
+                - HTTPSPORT=8043
             volumes:
                 - 'omada-data:/opt/tplink/EAPController/data'
                 - 'omada-work:/opt/tplink/EAPController/work'
                 - 'omada-logs:/opt/tplink/EAPController/logs'
             image: 'thost96/omada:latest'
 
-
 ## Changelog
+
+### 2.1.0 (pending)
+* (thost96) - add option to configure http and https web ui ports using env variables
+* (thost96) - fixed typos and updated README
 
 ### 2.0.3 (16.01.2021)
 * (thost96) - added docker build and push on release only, so dev builds don't get published

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 rm -f /opt/tplink/EAPController/data/db/journal/prealloc.*
+
+sed -i 's/http.connector.port=8088/http.connector.port='"${HTTPPORT}"'/g' /opt/tplink/EAPController/properties/jetty.properties \
+&& sed -i 's/https.connector.port=8043/https.connector.port='"${HTTPSPORT}"'/g' /opt/tplink/EAPController/properties/jetty.properties
+
 exec /opt/tplink/EAPController/jre/bin/java \
        -server -Xms128m -Xmx1024m -XX:MaxHeapFreeRatio=60 -XX:MinHeapFreeRatio=30 \
        -Deap.home=/opt/tplink/EAPController \


### PR DESCRIPTION
### 2.1.0 (16.01.2021)
* (thost96) - add option to configure http and https web ui ports using env variables
* (thost96) - fixed typos and updated README